### PR TITLE
split out test_ and resource functions for clarity, added pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+pythonpath = .

--- a/resources/blog_count.py
+++ b/resources/blog_count.py
@@ -1,0 +1,33 @@
+import asyncio
+from playwright.async_api import async_playwright
+
+async def count_blog_posts(url):
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page()
+        await page.goto(url)
+
+        # Count the number of blog posts on the first page
+        blog_posts_first_page = await page.query_selector_all('.blog-title')
+        count_first_page = len(blog_posts_first_page)
+
+        # Navigate to the second page
+        await page.click('text="Older Posts"')
+        await page.wait_for_selector('.blog-title')
+
+        # Count the number of blog posts on the second page
+        blog_posts_second_page = await page.query_selector_all('.blog-title')
+        count_second_page = len(blog_posts_second_page)
+
+        await browser.close()
+        return count_first_page + count_second_page
+
+async def main():
+    url = 'https://ocula.tech/resources'
+    total_posts = await count_blog_posts(url)
+    print(f"Total blog posts: {total_posts}")
+
+
+# keep in this file, to allow running manually for debug purposes
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/resources/openweather_api.py
+++ b/resources/openweather_api.py
@@ -1,0 +1,28 @@
+import requests
+import pprint
+
+# Function() for GET response of the OpenWeatherMap API for specified city, returnign data_set for future usage.
+
+def get_weather_by_city(city, weather_api_key, units = "metric"):
+    weather_url = f"http://api.openweathermap.org/data/2.5/weather?q={city}&appid={weather_api_key}&units={units}"
+    response = requests.get(weather_url)
+    data_set = response.json()
+    pprint.pprint(data_set)
+    return response, data_set
+    
+    #debugging purposes - \n etc...
+def print_weather_ocula(data_set):
+    main = data_set["main"]
+    print(f"\n\n\nMinimum Temperature: {main['temp_min']}")
+    print(f"Maximum Temperature: {main['temp_max']}")
+    print(f"Temperature: {main['temp']}")
+    print(f"Humidity: {main['humidity']}\n\n\n")    
+
+if __name__ == "__main__":
+    # Call the test function when the script is executed manually
+    # print data to terminal from both above functions
+    city = "Belfast"
+    weather_api_key = "08cde2ac41432dc445bb68b94c84edef"
+    get_weather_by_city(city, weather_api_key)
+    response, data_set = get_weather_by_city(city, weather_api_key)
+    print_weather_ocula(data_set)

--- a/test_openweather_api.py
+++ b/test_openweather_api.py
@@ -11,7 +11,7 @@ def test_weather_api():
     
     response = requests.get(weather_url)
     data_set = response.json()
-    # pprint.pprint(data_set)
+    pprint.pprint(data_set)
     
 # Verify the minimum, maximum, temperature, and humidity values exist in correct schema elements
 
@@ -25,7 +25,7 @@ def test_weather_api():
     assert "main" in data_set, "Expected 'main' key not found in the JSON response"
     
     if "temp_min" in main and "temp_max" in main and "temp" in main and "humidity" in main:
-        print(f"Minimum Temperature: {main['temp_min']}")
+        print(f"\n\n\nMinimum Temperature: {main['temp_min']}")
         print(f"Maximum Temperature: {main['temp_max']}")
         print(f"Temperature: {main['temp']}")
         print(f"Humidity: {main['humidity']}")
@@ -33,11 +33,6 @@ def test_weather_api():
         raise ValueError("One or more expected keys are missing from within 'main'")
     
 
-
-
-
-
-
+# Call the test function when the script is executed manually via Python
 if __name__ == "__main__":
-    # Call the test function when the script is executed
     test_weather_api()

--- a/tests/test_blog_counter.py
+++ b/tests/test_blog_counter.py
@@ -1,0 +1,13 @@
+import pytest
+import asyncio
+from resources.blog_count import count_blog_posts
+
+@pytest.mark.asyncio
+async def test_count_blog_posts():
+    url = 'https://ocula.tech/resources'
+    total_posts = await count_blog_posts(url)
+    assert total_posts == 25, f"Expected 25 blog posts, but found {total_posts}"
+
+# removed as only running via pytest, rather than standalone script
+# if __name__ == "__main__":
+#     asyncio.run(test_count_blog_posts())

--- a/tests/test_openweather_api.py
+++ b/tests/test_openweather_api.py
@@ -1,0 +1,44 @@
+import pytest
+import pprint
+from resources.openweather_api import get_weather_by_city
+
+# Test function() to validate the presence of specified keys in the JSON response.
+def test_get_weather_by_city():
+    city = "Belfast"
+    weather_api_key = "08cde2ac41432dc445bb68b94c84edef"
+    response, data_set = get_weather_by_city(city, weather_api_key)
+    pprint.pprint(data_set)
+    
+# Verify the minimum, maximum, temperature, and humidity values exist in correct schema elements
+
+    content_type = response.headers.get("Content-Type")
+    main = data_set["main"]
+
+    assert response.status_code == 200, "Unexpected Status Code: " + str(response.status_code)
+    assert content_type == "application/json; charset=utf-8", "Unexpected Content-Type: " + content_type
+    
+    # Check if the "main" key is present in the JSON response - holds relevant Temperature data
+    assert "main" in data_set, "Expected 'main' key not found in the JSON response"
+    
+    if "temp_min" in main and "temp_max" in main and "temp" in main and "humidity" in main:
+        print(f"Minimum Temperature: {main['temp_min']}")
+        print(f"Maximum Temperature: {main['temp_max']}")
+        print(f"Temperature: {main['temp']}")
+        print(f"Humidity: {main['humidity']}")
+    else:
+        raise ValueError("One or more expected keys are missing from within 'main'")
+    
+# alternative assertions for testing above
+    # assert response.status_code == 200, "Unexpected Status Code: " + str(response.status_code)
+    # assert content_type == "application/json; charset=utf-8", "Unexpected Content-Type: " + content_type
+    # assert "main" in data_set, "Expected 'main' key not found in the JSON response"
+    # assert "temp_min" in main, "Expected 'temp_min' key not found in the 'main' section"
+    # assert "temp_max" in main, "Expected 'temp_max' key not found in the 'main' section"
+    # assert "temp" in main, "Expected 'temp' key not found in the 'main' section"
+    # assert "humidity" in main, "Expected 'humidity' key not found in the 'main' section"
+    
+
+# removed as only running via pytest, rather than standalone script
+# if __name__ == "__main__":
+#     # Call the test function when the script is executed manually
+#     test_get_weather_by_city()


### PR DESCRIPTION
## Ocula Interview Prep

+ pytest.ini for importing from resources and adjusting `PYTHONPATH`
+ split original 2 hour assessment modules, to highlight `test_` module with assertions etc...

+ commented out multiple manual python execution/debugging elements, such as `if __name__ == "__main__":` where necessary